### PR TITLE
Scruffy dependencies for Debian based OSs

### DIFF
--- a/pip_accel/deps/debian.ini
+++ b/pip_accel/deps/debian.ini
@@ -16,3 +16,4 @@ m2crypto = libssl-dev swig
 mercurial = python-dev
 mysql-python = libmysqlclient-dev
 python-mcrypt = libmcrypt-dev
+scruffy = graphviz librsvg2-bin plotutils


### PR DESCRIPTION
Debian/Ubuntu dependencies for Scruffy.

Tested on Ubuntu 12.04, checked package names on packages.debian.org.
