### PR TITLE
Check for /etc/debian_version

### DIFF
--- a/pip_accel/deps/__init__.py
+++ b/pip_accel/deps/__init__.py
@@ -195,6 +195,13 @@ class DebianLinux(BasePlatform):
         if distributor_id.lower() in ('debian', 'ubuntu'):
             logger.debug("Using Debian package manager interface ..")
             return True
+        # If /etc/debian_version exists, this OS uses the Debian base files,
+        # and thus is a Debian derivative, which sometimes cannot be read
+        # from the lsb-release command. /etc/os-version is deprecated,
+        # so this isn't a good solution, I think this is.
+        elif os.path.exists("/etc/debian_version"):
+            return True
+
 
     def find_installed(self):
         """


### PR DESCRIPTION
Since lsb-release does not tell you if the OS is a derivative, checking for /etc/debian_version (which is only there if the OS uses the debian base_files) tells us if the OS is a Debian based one.

This fixes dependency searches on, for example, Elementary OS.

The other option would be to check for /etc/os-release, but some other OSes like Fedora deprecated and removed this file some time ago, and it requires parsing the file, while this is much faster.
