### PR TITLE
Use package url and version for binary cache file naming

### DIFF
--- a/pip_accel/__init__.py
+++ b/pip_accel/__init__.py
@@ -216,7 +216,7 @@ def install_requirements(requirements, install_prefix=ENVIRONMENT):
             if os.system('%s uninstall --yes %s >/dev/null 2>&1' % (pipes.quote(pip), pipes.quote(requirement.name))) == 0:
                 logger.info("Uninstalled previously installed package %s.", requirement.name)
             members = get_binary_dist(requirement.name, requirement.version,
-                                      requirement.source_directory,
+                                      requirement.source_directory, requirement.url,
                                       prefix=install_prefix, python=python)
             install_binary_dist(members, prefix=install_prefix, python=python)
     logger.info("Finished installing all requirements in %s.", install_timer)

--- a/pip_accel/bdist.py
+++ b/pip_accel/bdist.py
@@ -23,6 +23,7 @@ import subprocess
 import tarfile
 import tempfile
 import time
+import hashlib
 
 # External dependencies.
 from humanfriendly import Spinner, Timer
@@ -35,7 +36,7 @@ from pip_accel.utils import get_python_version
 # Initialize a logger for this module.
 logger = logging.getLogger(__name__)
 
-def get_binary_dist(package, version, directory, python='/usr/bin/python', prefix='/usr'):
+def get_binary_dist(package, version, directory, url, python='/usr/bin/python', prefix='/usr'):
     """
     Get the cached binary distribution archive that was previously built for
     the given package (name, version). If no archive has been cached yet, a
@@ -52,7 +53,13 @@ def get_binary_dist(package, version, directory, python='/usr/bin/python', prefi
     :returns: An iterable of tuples with two values each: A
               :py:class:`tarfile.TarInfo` object and a file-like object.
     """
-    cache_file = os.path.join(binary_index, '%s:%s:%s.tar.gz' % (package, version, get_python_version()))
+    if url:
+        tag = hashlib.sha1(version + url).hexdigest()
+    else:
+        tag = version
+
+    cache_file = os.path.join(binary_index, '%s:%s:%s.tar.gz' % (package, tag, get_python_version()))
+
     if not os.path.isfile(cache_file):
         logger.debug("%s (%s) hasn't been cached yet, doing so now.", package, version)
         # Build the binary distribution.

--- a/pip_accel/req.py
+++ b/pip_accel/req.py
@@ -80,6 +80,13 @@ class Requirement:
         return self.pip_requirement.installed_version
 
     @property
+    def url(self):
+        """
+        The url of the package. Based on :py:attr:`pip.req.InstallRequirement.url`.
+        """
+        return self.pip_requirement.url
+
+    @property
     def source_directory(self):
         """
         The pathname of the directory containing the unpacked source


### PR DESCRIPTION
It helps when dependencies are specified as VCS urls and have the same version in `setup.py` as already cached ones.

It works well when VCS url contains revision hash or tag id. It also works when branch spec is specified but doesn't take into account potential changes of the code of this branch through time.
