### PR TITLE
adding option to store bdist files in S3

### DIFF
--- a/pip_accel/bdist.py
+++ b/pip_accel/bdist.py
@@ -28,10 +28,12 @@ import tempfile
 import time
 
 # External dependencies.
+import boto
+from boto.s3.key import Key
 from humanfriendly import Spinner, Timer
 
 # Modules included in our package.
-from pip_accel.config import binary_index, on_debian
+from pip_accel.config import binary_index, on_debian, s3_cache_bucket, s3_cache_prefix
 from pip_accel.deps import sanity_check_dependencies
 from pip_accel.utils import get_python_version
 
@@ -77,7 +79,7 @@ def get_binary_dist(package, version, directory, url=None, python='/usr/bin/pyth
         url = None
     tag = hashlib.sha1(str(version + url).encode()).hexdigest() if url else version
     cache_file = os.path.join(binary_index, '%s:%s:%s.tar.gz' % (package, tag, get_python_version()))
-    if not os.path.isfile(cache_file):
+    if not cache_file_exists(cache_file, binary_index):
         logger.debug("%s (%s) hasn't been cached yet, doing so now.", package, version)
         # Build the binary distribution.
         try:
@@ -95,6 +97,7 @@ def get_binary_dist(package, version, directory, url=None, python='/usr/bin/pyth
         # moving the transformed binary distribution into its final place.
         os.rename(transformed_file, cache_file)
         logger.debug("%s (%s) cached as %s.", package, version, cache_file)
+        store_file_into_s3_cache(cache_file, binary_index)
     archive = tarfile.open(cache_file, 'r:gz')
     for member in archive.getmembers():
         yield member, archive.extractfile(member.name)
@@ -323,3 +326,44 @@ class NoBuildOutput(Exception):
     Raised by :py:func:`build_binary_dist()` when a binary distribution build
     fails to produce a binary distribution archive.
     """
+
+
+def cache_file_exists(cache_file, binary_index):
+    if os.path.isfile(cache_file):
+        return True
+    if s3_cache_bucket is None:
+        return False
+    bucket = get_s3_bucket()
+    s3_key = get_s3_key_path(binary_index, cache_file)
+    logger.info("Downloading {} from S3 cache.".format(s3_key))
+    key = bucket.get_key(s3_key)
+    if key is not None:
+        key.get_contents_to_filename(cache_file)
+        return True
+    return False
+
+
+def store_file_into_s3_cache(cache_file, binary_index):
+    if s3_cache_bucket is None:
+        return False
+    logger.debug("Storing {} into S3 cache.".format(cache_file, binary_index))
+    bucket = get_s3_bucket()
+    s3_key = get_s3_key_path(binary_index, cache_file)
+    logger.info("Storing file {} into S3 cache at {}.".format(cache_file, s3_key))
+    key = Key(bucket)
+    key.key = s3_key
+    key.set_contents_from_filename(cache_file)
+    return True
+
+
+def get_s3_key_path(binary_index, cache_file):
+    return '/'.join([s3_cache_prefix, cache_file.replace(binary_index + '/', '')])
+
+
+def get_s3_bucket():
+    return get_s3_connection().get_bucket(s3_cache_bucket)
+
+
+def get_s3_connection():
+    return boto.connect_s3()
+

--- a/pip_accel/config.py
+++ b/pip_accel/config.py
@@ -14,6 +14,7 @@ from pip_accel.utils import expand_user
 # Select the default location of the download cache and other files based on
 # the user running the pip-accel command (root goes to /var/cache/pip-accel,
 # otherwise ~/.pip-accel).
+s3_cache_bucket = None
 if os.getuid() == 0:
     download_cache = '/root/.pip/download-cache'
     pip_accel_cache = '/var/cache/pip-accel'
@@ -22,6 +23,9 @@ else:
     pip_accel_cache = expand_user('~/.pip-accel')
 
 # Enable overriding the default locations with environment variables.
+if 'PIP_S3_CACHE_BUCKET' in os.environ:
+    s3_cache_bucket = expand_user(os.environ['PIP_S3_CACHE_BUCKET'])
+    s3_cache_prefix = expand_user(os.environ.get('PIP_S3_CACHE_PREFIX', ''))
 if 'PIP_DOWNLOAD_CACHE' in os.environ:
     download_cache = expand_user(os.environ['PIP_DOWNLOAD_CACHE'])
 if 'PIP_ACCEL_CACHE' in os.environ:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 coloredlogs >= 0.4.6
 humanfriendly >= 1.6
 pip >= 1.4, < 1.5
+boto >= 2.32


### PR DESCRIPTION
- in addition to local file system
- uses PIP_S3_CACHE_BUCKET envrionment variable to indicate
  S3 use.
- option PIP_S3_CACHE_PREFIX environment variable sets a prefix
  (folder) to store the bdist files in, allowing for multiple
  OS-specific bdist folders.
