### PR TITLE
Adding max-retries to configuration and fixing issues with uninstall.

### DIFF
--- a/pip_accel/__init__.py
+++ b/pip_accel/__init__.py
@@ -357,13 +357,12 @@ class PipAccelerator(object):
         """
         install_timer = Timer()
         logger.info("Installing from binary distributions ..")
-        pip = os.path.join(sys.prefix, 'bin', 'pip')
         for requirement in requirements:
-            if run('{pip} uninstall --yes {package} >/dev/null 2>&1', pip=pip, package=requirement.name):
+            if run('pip uninstall --yes {package}', package=requirement.name):
                 logger.info("Uninstalled previously installed package %s.", requirement.name)
             if requirement.is_editable:
                 logger.debug("Installing %s (%s) in editable form using pip.", requirement.name, requirement.version)
-                if not run('{pip} install --no-deps --editable {url} >/dev/null 2>&1', pip=pip, url=requirement.url):
+                if not run('pip install --no-deps --editable {url}', url=requirement.url):
                     msg = "Failed to install %s (%s) in editable form!"
                     raise Exception(msg % (requirement.name, requirement.version))
             else:

--- a/pip_accel/__init__.py
+++ b/pip_accel/__init__.py
@@ -19,7 +19,7 @@ the :py:class:`PipAccelerator` class.
 """
 
 # Semi-standard module versioning.
-__version__ = '0.22.4'
+__version__ = '0.22.5'
 
 # Standard library modules.
 import logging

--- a/pip_accel/__init__.py
+++ b/pip_accel/__init__.py
@@ -19,7 +19,7 @@ the :py:class:`PipAccelerator` class.
 """
 
 # Semi-standard module versioning.
-__version__ = '0.22.3'
+__version__ = '0.22.4'
 
 # Standard library modules.
 import logging
@@ -65,7 +65,7 @@ class PipAccelerator(object):
     def __init__(self, config, validate=True):
         """
         Initialize the pip accelerator.
-        
+
         :param config: The pip-accel configuration (a :py:class:`.Config`
                        object).
         :param validate: ``True`` to run :py:func:`validate_environment()`,
@@ -176,7 +176,7 @@ class PipAccelerator(object):
         :param kw: Any keyword arguments are passed on to
                    :py:func:`install_requirements()`.
         """
-        requirements = self.get_requirements(arguments)
+        requirements = self.get_requirements(arguments, self.config.max_retries)
         self.install_requirements(requirements, **kw)
         self.cleanup_temporary_directories()
 

--- a/pip_accel/bdist.py
+++ b/pip_accel/bdist.py
@@ -158,7 +158,7 @@ class BinaryDistributionManager(object):
         # pip install into this as our target.
         temporary_dir = tempfile.mkdtemp()
         distutils_inst = install(Distribution())
-        distutils_inst.prefix = '' # This will be changed if we're in a virtualenv.
+        distutils_inst.prefix = '/usr' # This will be changed if we're in a virtualenv.
         distutils_inst.finalize_options()
         pip_target = os.path.normpath(temporary_dir + distutils_inst.install_lib)
         # Compose the command line needed to build the binary distribution.
@@ -260,11 +260,10 @@ class BinaryDistributionManager(object):
             # kind of awkward: I would like to use os.path.relpath() on them but
             # that won't give the correct result without some preprocessing...
             original_pathname = member.name
-            absolute_pathname = re.sub(r'^\./', '', original_pathname)
+            modified_pathname = re.sub(r'^\./', '/', original_pathname)
             if member.isdev():
-                logger.warn("Ignoring device file: %s.", absolute_pathname)
+                logger.warn("Ignoring device file: %s.", modified_pathname)
             elif not member.isdir():
-                modified_pathname = os.path.relpath(absolute_pathname, self.config.install_prefix)
                 if os.path.isabs(modified_pathname):
                     logger.warn("Failed to transform pathname in binary distribution to relative path! (original: %r, modified: %r)",
                                 original_pathname, modified_pathname)

--- a/pip_accel/bdist.py
+++ b/pip_accel/bdist.py
@@ -260,7 +260,7 @@ class BinaryDistributionManager(object):
             # kind of awkward: I would like to use os.path.relpath() on them but
             # that won't give the correct result without some preprocessing...
             original_pathname = member.name
-            modified_pathname = re.sub(r'^\./', '/', original_pathname)
+            modified_pathname = re.sub(r'^\./', '', original_pathname)
             if member.isdev():
                 logger.warn("Ignoring device file: %s.", modified_pathname)
             elif not member.isdir():

--- a/pip_accel/bdist.py
+++ b/pip_accel/bdist.py
@@ -162,8 +162,7 @@ class BinaryDistributionManager(object):
         distutils_inst.finalize_options()
         pip_target = os.path.normpath(temporary_dir + distutils_inst.install_lib)
         # Compose the command line needed to build the binary distribution.
-        pip = os.path.join(sys.prefix, 'bin', 'pip')
-        command_line = ' '.join(pipes.quote(t) for t in [pip, 'install', '.', '--target', pip_target])
+        command_line = ' '.join(pipes.quote(t) for t in ['pip', 'install', '.', '--target', pip_target])
         logger.debug("Executing external command: %s", command_line)
         # Redirect all output of the build to a temporary file.
         fd, temporary_file = tempfile.mkstemp()

--- a/pip_accel/bdist.py
+++ b/pip_accel/bdist.py
@@ -158,7 +158,7 @@ class BinaryDistributionManager(object):
         # pip install into this as our target.
         temporary_dir = tempfile.mkdtemp()
         distutils_inst = install(Distribution())
-        distutils_inst.prefix = '/usr' # This will be changed if we're in a virtualenv.
+        distutils_inst.prefix = '' # This will be changed if we're in a virtualenv.
         distutils_inst.finalize_options()
         pip_target = os.path.normpath(temporary_dir + distutils_inst.install_lib)
         # Compose the command line needed to build the binary distribution.

--- a/pip_accel/caches/__init__.py
+++ b/pip_accel/caches/__init__.py
@@ -202,7 +202,7 @@ class CacheManager(object):
             # every run (not good for performance ;-).
             url = None
         tag = sha1(requirement.version + url) if url else requirement.version
-        return 'v%i/%s:%s:%s.tar.gz' % (self.config.cache_format_revision,
+        return 'v%i/%s-%s-%s.tar.gz' % (self.config.cache_format_revision,
                                         requirement.name, tag, get_python_version())
 
 

--- a/pip_accel/config.py
+++ b/pip_accel/config.py
@@ -1,7 +1,7 @@
 # Configuration defaults for the pip accelerator.
 #
 # Author: Peter Odding <peter.odding@paylogic.eu>
-# Last Change: December 11, 2014
+# Last Change: January 26, 2015
 # URL: https://github.com/paylogic/pip-accel
 
 """
@@ -55,6 +55,7 @@ Here is an example of the available options:
 
            [pip-accel]
            auto-install = yes
+           max-retries = 10
            data-directory = ~/.pip-accel
            download-cache = ~/.pip/download-cache
            s3-bucket = my-shared-pip-accel-binary-cache
@@ -288,6 +289,26 @@ class Config(object):
                          configuration_option='auto-install')
         if value is not None:
             return coerce_boolean(value)
+
+    @cached_property
+    def max_retries(self):
+        """
+        The number of times to retry building a package if it fails.
+
+        - Environment variable: ``$PIP_ACCEL_MAX_RETRIES`` should be
+          a nonnegative integer, e.g. 10.
+        - Configuration option: ``max-retries``
+        - Default: ``10``
+        """
+        value = self.get(property_name='max_retries',
+                         environment_variable='PIP_ACCEL_MAX_RETRIES',
+                         configuration_option='max-retries')
+        try:
+            n = int(value)
+            if n >= 0:
+                return n
+        except:
+            return 10
 
     @cached_property
     def s3_cache_url(self):


### PR DESCRIPTION
This fixes and issue we are observing where upgrades of packages do not happen cleanly. The reason is that `pip-accel uninstall` does not remove package contents.

If you `pip-accel install scikit-learn==0.14.1` and then `pip uninstall scikit-learn`, there will still be an sklearn directory with Python code in it. Upgrading to `scikit-learn==0.15.2` afterward will give a broken build.

```
$ python -c 'from sklearn.metrics.pairwise import manhattan_distances'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/sklearn/metrics/__init__.py", line 6, in <module>
    from .metrics import (accuracy_score,
  File "/usr/local/lib/python2.7/dist-packages/sklearn/metrics/metrics.py", line 31, in <module>
    from ..preprocessing import LabelBinarizer, label_binarize
  File "/usr/local/lib/python2.7/dist-packages/sklearn/preprocessing/__init__.py", line 6, in <module>
    from .data import Binarizer
  File "/usr/local/lib/python2.7/dist-packages/sklearn/preprocessing/data.py", line 25, in <module>
    from ..utils.sparsefuncs import inplace_column_scale
ImportError: cannot import name inplace_column_scale
```

The reason `pip-accel` can't uninstall binary packages is that it is building them using `python setup.py bdist` or `python setup.py bdist_dumb`. These commands do not create an `installed-files.txt`, which is what `pip` uses to track which files belong to a package.

This pull request fixes the issue by doing the following:
* Create a temporary directory `<TEMP DIR>`, and inside it make a structure like `usr/lib/python2.7/site-packages/` according to what `distutils` instructs.
* Inside the package source run `pip install . --target <TEMP DIR>/<SITE PACKAGES DIR>/`. This is like doing a dumb binary distribution, but includes the files `pip` uses for package management.
* Tar the contents of `<TEMP DIR>` and, move it to the dist directory, and continue as before.

It also adds a `max-retries` option to the `pip-accel` configuration, allowing the user to limit the number of potentially costly attempts to build a package. This is important when building a lot of versions of different packages in batch, some of which may no longer be available.