### PR TITLE
Fix tests under OS X.

### DIFF
--- a/pip_accel/tests.py
+++ b/pip_accel/tests.py
@@ -502,6 +502,8 @@ class PipAccelTestCase(unittest.TestCase):
         # Clone the remote git repository.
         temporary_directory = create_temporary_directory()
         git_checkout = os.path.join(temporary_directory, 'verboselogs')
+        # Resolve symlinks (Under OS X /var is symlink to /private/var).
+        git_checkout = os.path.realpath(git_checkout)
         git_remote = 'https://github.com/xolox/python-verboselogs.git'
         if os.system('git clone --depth=1 %s %s' % (pipes.quote(git_remote), pipes.quote(git_checkout))) != 0:
             logger.warning("Skipping editable installation test (git clone seems to have failed).")


### PR DESCRIPTION
Without this fix the followin error appears on my machine during "tox" command:

```python
>       assert python_module.startswith(git_checkout), "Editable Python module not located under git checkout of project!"
E       AssertionError: Editable Python module not located under git checkout of project!
E       assert <built-in method startswith of unicode object at 0x110193cf0>('/var/folders/14/0chn1ycd3ts7btmvnthw3n344h1k2m/T/tmpXBWxd8/verboselogs')
E        +  where <built-in method startswith of unicode object at 0x110193cf0> = '/private/var/folders/14/0chn1ycd3ts7btmvnthw3n344h1k2m/T/tmpXBWxd8/verboselogs/verboselogs.py'.startswith

pip_accel/tests.py:522: AssertionError
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
================================ 1 failed, 5 passed in 5.42 seconds =================================
ERROR: InvocationError: '/Users/yoprst/Projects/pip-accel/.tox/py26/bin/py.test --capture=no --exitfirst pip_accel/tests.py'
```
