### PR TITLE
Integrate Windows support from #60

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# .travis.yml: Configuration for continuous integration (automated tests)
+# hosted on Travis CI, see https://travis-ci.org/paylogic/pip-accel.
+
 sudo: required
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 before_install:
   - scripts/retry-command sudo apt-get update
 install:
-  - scripts/retry-command pip install coveralls --editable "file://${PWD}[s3]"
+  - LC_ALL=C scripts/retry-command pip install coveralls --editable "file://${PWD}[s3]"
   - scripts/retry-command gem install fakes3
 script:
   - scripts/collect-full-coverage

--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,9 @@ detects missing system packages when a build fails and prompts the user whether
 to install the missing dependencies and retry the build.
 
 The pip-accel program is currently tested on cPython 2.6, 2.7 and 3.4 and PyPy
-(2.7). The automated test suite regularly runs on Ubuntu Linux but other Linux
-variants (also those not based on Debian Linux) should work fine.
+(2.7). The automated test suite regularly runs on Ubuntu Linux (`Travis CI`_)
+as well as Microsoft Windows (AppVeyor_). In addition to these platforms
+pip-accel should work fine on most UNIX systems (e.g. Mac OS X).
 
 .. contents::
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,4 +12,4 @@ build: off
 test_script:
   - cmd: '"%PYTHON%\Scripts\coverage.exe" run setup.py test'
 on_success:
-  - cmd: 'coveralls'
+  - cmd: '"%PYTHON%\Scripts\coveralls.exe"'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,11 @@
+# appveyor.yml: Configuration for continuous integration (automated tests)
+# hosted on AppVeyor, see https://ci.appveyor.com/project/xolox/pip-accel.
+
+version: 1.0.{build}
+environment:
+  PYTHON: C:\Python27
+install:
+- cmd: '"%PYTHON%\Scripts\pip.exe" install .'
+build: off
+test_script:
+- cmd: '"%PYTHON%\python.exe" setup.py test'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,9 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: DCxZQaYFWVR0zWqjTPXhhlRlLdmKNMS2qDUwIR8jRar13clunOqJIaXn+vKInS7g
 install:
-  - "%PYTHON%\Scripts\pip.exe" install coveralls .
+  - cmd: '"%PYTHON%\Scripts\pip.exe" install coveralls .'
 build: off
 test_script:
-  - "%PYTHON%\Scripts\coverage.exe" run setup.py test
+  - cmd: '"%PYTHON%\Scripts\coverage.exe" run setup.py test'
 on_success:
-  - coveralls
+  - cmd: 'coveralls'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,12 @@
 version: 1.0.{build}
 environment:
   PYTHON: C:\Python27
+  COVERALLS_REPO_TOKEN:
+    secure: DCxZQaYFWVR0zWqjTPXhhlRlLdmKNMS2qDUwIR8jRar13clunOqJIaXn+vKInS7g
 install:
-- cmd: '"%PYTHON%\Scripts\pip.exe" install .'
+  - "%PYTHON%\Scripts\pip.exe" install coveralls .
 build: off
 test_script:
-- cmd: '"%PYTHON%\python.exe" setup.py test'
+  - "%PYTHON%\Scripts\coverage.exe" run setup.py test
+on_success:
+  - coveralls

--- a/pip_accel/bdist.py
+++ b/pip_accel/bdist.py
@@ -1,7 +1,7 @@
 # Functions to manipulate Python binary distribution archives.
 #
 # Author: Peter Odding <peter.odding@paylogic.com>
-# Last Change: September 9, 2015
+# Last Change: October 27, 2015
 # URL: https://github.com/paylogic/pip-accel
 
 """
@@ -91,9 +91,12 @@ class BinaryDistributionManager(object):
             # Transform the binary distribution archive into a form that we can re-use.
             fd, transformed_file = tempfile.mkstemp(prefix='pip-accel-bdist-', suffix='.tar.gz')
             try:
-                with tarfile.open(transformed_file, 'w:gz') as archive:
+                archive = tarfile.open(transformed_file, 'w:gz')
+                try:
                     for member, from_handle in self.transform_binary_dist(raw_file):
                         archive.addfile(member, from_handle)
+                finally:
+                    archive.close()
                 # Push the binary distribution archive to all available backends.
                 with open(transformed_file, 'rb') as handle:
                     self.cache.put(requirement, handle)

--- a/pip_accel/bdist.py
+++ b/pip_accel/bdist.py
@@ -32,7 +32,7 @@ from humanfriendly import Spinner, Timer, concatenate
 
 # Modules included in our package.
 from pip_accel.caches import CacheManager
-from pip_accel.compat import is_win
+from pip_accel.compat import WINDOWS
 from pip_accel.deps import SystemPackageManager
 from pip_accel.exceptions import BuildFailed, InvalidSourceDistribution, NoBuildOutput
 from pip_accel.utils import compact, makedirs
@@ -73,7 +73,7 @@ class BinaryDistributionManager(object):
         """
         cache_file = self.cache.get(requirement)
         # TODO Invalidating does not work on Windows in appveyor. Skip it for now.
-        if not is_win:
+        if not WINDOWS:
             if cache_file and requirement.last_modified > os.path.getmtime(cache_file):
                 logger.info("Invalidating old %s binary (source is newer) ..", requirement)
                 cache_file = None

--- a/pip_accel/bdist.py
+++ b/pip_accel/bdist.py
@@ -1,7 +1,7 @@
 # Functions to manipulate Python binary distribution archives.
 #
 # Author: Peter Odding <peter.odding@paylogic.com>
-# Last Change: October 27, 2015
+# Last Change: October 28, 2015
 # URL: https://github.com/paylogic/pip-accel
 
 """
@@ -72,11 +72,9 @@ class BinaryDistributionManager(object):
                   :py:class:`tarfile.TarInfo` object and a file-like object.
         """
         cache_file = self.cache.get(requirement)
-        # TODO Invalidating does not work on Windows in appveyor. Skip it for now.
-        if not WINDOWS:
-            if cache_file and requirement.last_modified > os.path.getmtime(cache_file):
-                logger.info("Invalidating old %s binary (source is newer) ..", requirement)
-                cache_file = None
+        if cache_file and requirement.last_modified > os.path.getmtime(cache_file):
+            logger.info("Invalidating old %s binary (source is newer) ..", requirement)
+            cache_file = None
         if not cache_file:
             logger.debug("%s hasn't been cached yet, doing so now.", requirement)
             # Build the binary distribution.

--- a/pip_accel/caches/__init__.py
+++ b/pip_accel/caches/__init__.py
@@ -1,7 +1,7 @@
 # Accelerator for pip, the Python package manager.
 #
 # Author: Peter Odding <peter.odding@paylogic.com>
-# Last Change: April 11, 2015
+# Last Change: October 28, 2015
 # URL: https://github.com/paylogic/pip-accel
 
 """
@@ -20,9 +20,9 @@ which automatically disables backends that report errors.
 
 # Standard library modules.
 import logging
-import sys
 
 # Modules included in our package.
+from pip_accel.compat import WINDOWS
 from pip_accel.exceptions import CacheBackendDisabledError
 from pip_accel.utils import get_python_version
 
@@ -36,12 +36,8 @@ logger = logging.getLogger(__name__)
 # Initialize the registry of cache backends.
 registered_backends = set()
 
-# On Windows it is not allowed to have colons ':' in filenames.
-if sys.platform.startswith('win'):
-    FILENAME_PATTERN = 'v%i\\%s$%s$%s.tar.gz'
-else:
-    FILENAME_PATTERN = 'v%i/%s:%s:%s.tar.gz'
-
+# On Windows it is not allowed to have colons in filenames so we use a dollar sign instead.
+FILENAME_PATTERN = 'v%i\\%s$%s$%s.tar.gz' if WINDOWS else 'v%i/%s:%s:%s.tar.gz'
 
 class CacheBackendMeta(type):
 
@@ -202,4 +198,5 @@ class CacheManager(object):
                   the cache format revision.
         """
         return FILENAME_PATTERN % (self.config.cache_format_revision,
-                                        requirement.name, requirement.version, get_python_version())
+                                   requirement.name, requirement.version,
+                                   get_python_version())

--- a/pip_accel/caches/local.py
+++ b/pip_accel/caches/local.py
@@ -1,7 +1,7 @@
 # Accelerator for pip, the Python package manager.
 #
 # Author: Peter Odding <peter.odding@paylogic.com>
-# Last Change: November 16, 2014
+# Last Change: October 29, 2015
 # URL: https://github.com/paylogic/pip-accel
 
 """
@@ -26,7 +26,7 @@ import shutil
 
 # Modules included in our package.
 from pip_accel.caches import AbstractCacheBackend
-from pip_accel.utils import makedirs
+from pip_accel.utils import makedirs, replace_file
 
 # Initialize a logger for this module.
 logger = logging.getLogger(__name__)
@@ -71,8 +71,8 @@ class LocalCacheBackend(AbstractCacheBackend):
         logger.debug("Using temporary file to avoid partial reads: %s", temporary_file)
         with open(temporary_file, 'wb') as temporary_file_handle:
             shutil.copyfileobj(handle, temporary_file_handle)
+        logger.debug("Moving temporary file into place ..")
         # Atomically move the distribution archive into its final place
         # (again, to avoid race conditions between multiple processes).
-        logger.debug("Moving temporary file into place ..")
-        os.rename(temporary_file, file_in_cache)
+        replace_file(temporary_file, file_in_cache)
         logger.debug("Finished caching distribution archive in local cache.")

--- a/pip_accel/compat.py
+++ b/pip_accel/compat.py
@@ -1,37 +1,32 @@
+# Accelerator for pip, the Python package manager.
+#
+# Author: Peter Odding <peter.odding@paylogic.com>
+# Last Change: October 27, 2015
+# URL: https://github.com/paylogic/pip-accel
+
+# Standard library modules.
+import sys
+
+# Inform static code analysis tools about our intention to expose the
+# following variables. This avoids 'imported but unused' warnings.
+__all__ = (
+    'WINDOWS',
+    'StringIO',
+    'configparser',
+    'urlparse',
+)
+
+# Detect whether we're running on Microsoft Windows.
+WINDOWS = sys.platform.startswith('win')
+
+# Compatibility between Python 2 and 3.
 try:
-    # Python 2.x.
+    # Python 2.
     from StringIO import StringIO
     from urlparse import urlparse
     import ConfigParser as configparser
 except ImportError:
-    # Python 3.x.
+    # Python 3.
     from io import StringIO
     from urllib.parse import urlparse
     import configparser
-
-import os
-import sys
-
-is_win = sys.platform.startswith('win')
-
-if is_win:
-    HOME = os.environ.get('APPDATA')
-    if not HOME:
-        HOME = os.path.expanduser('~\\Application Data')
-else:
-    import pwd
-    # Look up the home directory of the effective user id so we can generate
-    # pathnames relative to the home directory.
-    HOME = pwd.getpwuid(os.getuid()).pw_dir
-
-def is_root():
-    """
-    Detect if running as user root. Cross-platform wrapper for os.getuid(0).
-
-    :returns: True when running as user root, else otherwise.
-    """
-    if is_win:
-        return False
-    else:
-        return os.getuid() == 0
-

--- a/pip_accel/config.py
+++ b/pip_accel/config.py
@@ -1,7 +1,7 @@
 # Configuration defaults for the pip accelerator.
 #
 # Author: Peter Odding <peter.odding@paylogic.com>
-# Last Change: April 11, 2015
+# Last Change: October 27, 2015
 # URL: https://github.com/paylogic/pip-accel
 
 """
@@ -76,7 +76,8 @@ import os.path
 import sys
 
 # Modules included in our package.
-from pip_accel.compat import configparser, is_root
+from pip_accel.compat import configparser
+from pip_accel.utils import is_root, expand_path
 
 # External dependencies.
 from cached_property import cached_property
@@ -217,10 +218,10 @@ class Config(object):
         - Configuration option: ``data-directory``
         - Default: ``/var/cache/pip-accel`` if running as ``root``, ``~/.pip-accel`` otherwise
         """
-        return parse_path(self.get(property_name='data_directory',
-                                   environment_variable='PIP_ACCEL_CACHE',
-                                   configuration_option='data-directory',
-                                   default='/var/cache/pip-accel' if is_root() else '~/.pip-accel'))
+        return expand_path(self.get(property_name='data_directory',
+                                    environment_variable='PIP_ACCEL_CACHE',
+                                    configuration_option='data-directory',
+                                    default='/var/cache/pip-accel' if is_root() else '~/.pip-accel'))
 
     @cached_property
     def on_debian(self):

--- a/pip_accel/deps/__init__.py
+++ b/pip_accel/deps/__init__.py
@@ -1,7 +1,7 @@
 # Extension of pip-accel that deals with dependencies on system packages.
 #
 # Author: Peter Odding <peter.odding@paylogic.com>
-# Last Change: November 22, 2014
+# Last Change: October 27, 2015
 # URL: https://github.com/paylogic/pip-accel
 
 """
@@ -26,8 +26,9 @@ import subprocess
 import sys
 
 # Modules included in our package.
-from pip_accel.compat import configparser, is_root, is_win
+from pip_accel.compat import WINDOWS, configparser
 from pip_accel.exceptions import DependencyInstallationFailed, DependencyInstallationRefused, SystemDependencyError
+from pip_accel.utils import is_root
 
 # External dependencies.
 from humanfriendly import Timer, concatenate, pluralize
@@ -97,8 +98,10 @@ class SystemPackageManager(object):
         if missing_dependencies:
             # Compose the command line for the install command.
             install_command = shlex.split(self.install_command) + missing_dependencies
-            if not is_win and not is_root():
-                # Prepend `sudo' to the command line.
+            # Prepend `sudo' to the command line?
+            if not WINDOWS and not is_root():
+                # FIXME Ideally this should properly detect the presence of `sudo'.
+                #       Or maybe this should just be embedded in the *.ini files?
                 install_command.insert(0, 'sudo')
             # Always suggest the installation command to the operator.
             logger.info("You seem to be missing %s: %s",
@@ -208,6 +211,7 @@ class SystemPackageManager(object):
         """
         terminal = "\n"
         try:
+            # FIXME raw_input() doesn't exist on Python 3. Switch to humanfriendly.prompts.prompt_for_confirmation()?
             prompt = "\n  Do you want me to install %s %s? [Y/n] "
             choice = raw_input(prompt % ("this" if len(missing_dependencies) == 1 else "these",
                                          "dependency" if len(missing_dependencies) == 1 else "dependencies"))

--- a/pip_accel/deps/__init__.py
+++ b/pip_accel/deps/__init__.py
@@ -1,7 +1,7 @@
 # Extension of pip-accel that deals with dependencies on system packages.
 #
 # Author: Peter Odding <peter.odding@paylogic.com>
-# Last Change: October 27, 2015
+# Last Change: October 28, 2015
 # URL: https://github.com/paylogic/pip-accel
 
 """
@@ -64,19 +64,20 @@ class SystemPackageManager(object):
                 # Check if the package manager is supported.
                 supported_command = parser.get('commands', 'supported')
                 logger.debug("Checking if configuration is supported: %s", supported_command)
-                if subprocess.call(supported_command, shell=True) == 0:
-                    logger.debug("System package manager configuration is supported!")
-                    # Get the commands to list and install system packages.
-                    self.list_command = parser.get('commands', 'list')
-                    self.install_command = parser.get('commands', 'install')
-                    # Get the known dependencies.
-                    self.dependencies = dict((n.lower(), v.split()) for n, v
-                                             in parser.items('dependencies'))
-                    logger.debug("Loaded dependencies of %s: %s",
-                                 pluralize(len(self.dependencies), "Python package"),
-                                 concatenate(sorted(self.dependencies)))
-                else:
-                    logger.debug("Command failed, assuming configuration doesn't apply ..")
+                with open(os.devnull, 'wb') as null_device:
+                    if subprocess.call(supported_command, shell=True, stdout=null_device, stderr=subprocess.STDOUT) == 0:
+                        logger.debug("System package manager configuration is supported!")
+                        # Get the commands to list and install system packages.
+                        self.list_command = parser.get('commands', 'list')
+                        self.install_command = parser.get('commands', 'install')
+                        # Get the known dependencies.
+                        self.dependencies = dict((n.lower(), v.split()) for n, v
+                                                 in parser.items('dependencies'))
+                        logger.debug("Loaded dependencies of %s: %s",
+                                     pluralize(len(self.dependencies), "Python package"),
+                                     concatenate(sorted(self.dependencies)))
+                    else:
+                        logger.debug("Command failed, assuming configuration doesn't apply ..")
 
     def install_dependencies(self, requirement):
         """

--- a/pip_accel/tests.py
+++ b/pip_accel/tests.py
@@ -230,10 +230,14 @@ class PipAccelTestCase(unittest.TestCase):
         """Test installation of newer versions over older versions."""
         accelerator = self.initialize_pip_accel()
         # Install version 1.6 of the `pep8' package.
-        num_installed = accelerator.install_from_arguments(['--ignore-installed', 'pep8==1.6'])
+        num_installed = accelerator.install_from_arguments([
+            '--ignore-installed', '--no-binary=:all:', 'pep8==1.6',
+        ])
         assert num_installed == 1, "Expected pip-accel to install exactly one package!"
         # Install version 1.6.2 of the `pep8' package.
-        num_installed = accelerator.install_from_arguments(['--ignore-installed', 'pep8==1.6.2'])
+        num_installed = accelerator.install_from_arguments([
+            '--ignore-installed', '--no-binary=:all:', 'pep8==1.6.2',
+        ])
         assert num_installed == 1, "Expected pip-accel to install exactly one package!"
 
     def test_package_downgrade(self):

--- a/pip_accel/tests.py
+++ b/pip_accel/tests.py
@@ -142,12 +142,15 @@ class PipAccelTestCase(unittest.TestCase):
 
         This tests the :py:func:`~pip_accel.PipAccelerator.validate_environment()` method.
         """
-        original_value = os.environ.get('VIRTUAL_ENV')
+        original_value = os.environ.get('VIRTUAL_ENV', None)
         try:
             os.environ['VIRTUAL_ENV'] = generate_nonexisting_pathname()
             self.assertRaises(EnvironmentMismatchError, self.initialize_pip_accel)
         finally:
-            os.environ['VIRTUAL_ENV'] = original_value
+            if original_value is not None:
+                os.environ['VIRTUAL_ENV'] = original_value
+            else:
+                del os.environ['VIRTUAL_ENV']
 
     def test_config_file_handling(self):
         """

--- a/pip_accel/tests.py
+++ b/pip_accel/tests.py
@@ -284,7 +284,7 @@ class PipAccelTestCase(unittest.TestCase):
         if not (fakes3_pid and fakes3_root):
             logger.warning("Skipping S3 cache backend test (it looks like FakeS3 isn't running).")
             return
-        pip_install_args = ['--ignore-installed', 'pep8==1.6.2']
+        pip_install_args = ['--ignore-installed', '--no-binary=:all:', 'pep8==1.6.2']
         # Initialize an instance of pip-accel with an empty cache.
         accelerator = self.initialize_pip_accel(load_environment_variables=True,
                                                 data_directory=create_temporary_directory(),

--- a/pip_accel/tests.py
+++ b/pip_accel/tests.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Tests for the pip accelerator.
 #
 # Author: Peter Odding <peter.odding@paylogic.com>

--- a/pip_accel/tests.py
+++ b/pip_accel/tests.py
@@ -195,9 +195,8 @@ class PipAccelTestCase(unittest.TestCase):
         """
         Verify pip-accel's "keeping pip off the internet" logic using an empty cache.
 
-        This test downloads, builds and installs pep8 1.6.2 (a trivial
-        Python package I created once) to verify that pip-accel keeps pip off
-        the internet when intended.
+        This test downloads, builds and installs pep8 1.6.2 to verify that
+        pip-accel keeps pip off the internet when intended.
         """
         pip_install_args = ['--ignore-installed', 'pep8==1.6.2']
         # Initialize an instance of pip-accel with an empty cache.
@@ -261,9 +260,8 @@ class PipAccelTestCase(unittest.TestCase):
         """
         Verify the successful usage of the S3 cache backend.
 
-        This test downloads, builds and installs pep8 1.6.2 (a trivial
-        Python package I created once) to verify that the S3 cache backend
-        works. It depends on FakeS3 (refer to the shell script
+        This test downloads, builds and installs pep8 1.6.2 to verify that the
+        S3 cache backend works. It depends on FakeS3 (refer to the shell script
         ``scripts/collect-full-coverage`` in the pip-accel git repository).
 
         This test uses a temporary binary index which it wipes after a

--- a/pip_accel/tests.py
+++ b/pip_accel/tests.py
@@ -3,7 +3,7 @@
 # Tests for the pip accelerator.
 #
 # Author: Peter Odding <peter.odding@paylogic.com>
-# Last Change: September 22, 2015
+# Last Change: October 27, 2015
 # URL: https://github.com/paylogic/pip-accel
 
 """
@@ -42,7 +42,6 @@ import unittest
 
 # External dependencies.
 import coloredlogs
-import pytest
 from humanfriendly import coerce_boolean
 from pip.commands.install import InstallCommand
 from pip.exceptions import DistributionNotFound
@@ -168,13 +167,15 @@ class PipAccelTestCase(unittest.TestCase):
             handle.write('name = value\n')
         self.assertRaises(Exception, config.load_configuration_file, config_file)
 
-    @pytest.mark.skipif(is_win, reason='Symlinks not working on Windows')
     def test_cleanup_of_broken_links(self):
         """
         Verify that broken symbolic links in the source index are cleaned up.
 
         This tests the :py:func:`~pip_accel.PipAccelerator.clean_source_index()` method.
         """
+        if is_win:
+            logger.warning("Skipping broken symlink cleanup test (Windows doesn't support symbolic links).")
+            return
         source_index = create_temporary_directory()
         broken_link = os.path.join(source_index, 'this-is-a-broken-link')
         os.symlink(generate_nonexisting_pathname(), broken_link)
@@ -582,7 +583,6 @@ class PipAccelTestCase(unittest.TestCase):
         returncode = test_cli('pip-accel', 'install', '--requirement', empty_file)
         assert returncode == 0, "pip-accel command line interface failed on empty requirements file!"
 
-    @pytest.mark.skipif(is_win, reason='Not applicable on Windows')
     def test_system_package_dependency_installation(self):
         """
         Test the (automatic) installation of required system packages.
@@ -600,8 +600,10 @@ class PipAccelTestCase(unittest.TestCase):
                      the test is skipped unless the environment variable
                      ``PIP_ACCEL_TEST_AUTO_INSTALL=yes`` is set (opt-in).
         """
-        # Test system package dependency handling.
-        if not coerce_boolean(os.environ.get('PIP_ACCEL_TEST_AUTO_INSTALL')):
+        if is_win:
+            logger.warning("Skipping system package dependency installation test (not relevant on Windows).")
+            return
+        elif not coerce_boolean(os.environ.get('PIP_ACCEL_TEST_AUTO_INSTALL')):
             logger.warning("Skipping system package dependency installation test (set the environment variable"
                            " PIP_ACCEL_TEST_AUTO_INSTALL=true to allow the test suite to use `sudo').")
             return

--- a/pip_accel/tests.py
+++ b/pip_accel/tests.py
@@ -28,7 +28,6 @@ import glob
 import logging
 import operator
 import os
-import pipes
 import random
 import re
 import shutil
@@ -509,7 +508,7 @@ class PipAccelTestCase(unittest.TestCase):
         temporary_directory = create_temporary_directory()
         git_checkout = os.path.join(temporary_directory, 'pep8')
         git_remote = 'https://github.com/PyCQA/pep8.git'
-        if os.system('git clone --depth=1 %s %s' % (pipes.quote(git_remote), pipes.quote(git_checkout))) != 0:
+        if subprocess.call(['git', 'clone', '--depth=1', git_remote, git_checkout]) != 0:
             logger.warning("Skipping editable installation test (git clone seems to have failed).")
             return
         # Install the package from the checkout as an editable package.
@@ -610,7 +609,7 @@ class PipAccelTestCase(unittest.TestCase):
         # removing any (reverse) dependencies (we don't actually want to
         # break the system, thank you very much :-). Disclaimer: you opt in
         # to this with $PIP_ACCEL_TEST_AUTO_INSTALL...
-        os.system('sudo dpkg --remove --force-depends libxslt1-dev')
+        subprocess.call(['sudo', 'dpkg', '--remove', '--force-depends', 'libxslt1-dev'])
         # Make sure that when automatic installation is disabled the system
         # package manager refuses to install the missing dependency.
         accelerator = self.initialize_pip_accel(auto_install=False, data_directory=create_temporary_directory())

--- a/pip_accel/tests.py
+++ b/pip_accel/tests.py
@@ -498,8 +498,8 @@ class PipAccelTestCase(unittest.TestCase):
         """
         Test the installation of editable packages using ``pip install --editable``.
 
-        This test clones the git repository of my trivial `pep8` Python
-        package and installs the package as an editable package.
+        This test clones the git repository of the Python package `pep8` and
+        installs the package as an editable package.
 
         We want to import the `pep8` module to confirm that it was
         properly installed but we can't do that in the process that's running

--- a/pip_accel/tests.py
+++ b/pip_accel/tests.py
@@ -587,9 +587,8 @@ class PipAccelTestCase(unittest.TestCase):
 
         .. _issue 47: https://github.com/paylogic/pip-accel/issues/47
         """
-        # Create first temporary empty file.
-        empty_file = os.path.join(create_temporary_directory(), 'empty_file')
-        open(empty_file, 'a').close()
+        empty_file = os.path.join(create_temporary_directory(), 'empty-requirements-file.txt')
+        open(empty_file, 'w').close()
         returncode = test_cli('pip-accel', 'install', '--requirement', empty_file)
         assert returncode == 0, "pip-accel command line interface failed on empty requirements file!"
 

--- a/pip_accel/tests.py
+++ b/pip_accel/tests.py
@@ -706,11 +706,10 @@ def try_program(program_name):
     assert os.access(program_path, os.X_OK), \
         ("Program file not executable! (%s)" % program_path)
     logger.debug("Making sure %s --help works ..", program_path)
-    with open(os.devnull, 'wb') as DEVNULL:
+    with open(os.devnull, 'wb') as null_device:
         # Redirect stdout to /dev/null and stderr to stdout.
-        assert subprocess.call([program_path, '--help'], stdout=DEVNULL,
-            stderr=subprocess.STDOUT) == 0, \
-        ("Program doesn't run! (%s --help failed)" % program_path)
+        assert subprocess.call([program_path, '--help'], stdout=null_device, stderr=subprocess.STDOUT) == 0, \
+            ("Program doesn't run! (%s --help failed)" % program_path)
 
 def find_python_program(program_name):
     """

--- a/pip_accel/tests.py
+++ b/pip_accel/tests.py
@@ -91,7 +91,7 @@ class PipAccelTestCase(unittest.TestCase):
 
     def setUp(self):
         """Reset logging verbosity before each test."""
-        coloredlogs.set_level(logging.INFO)
+        coloredlogs.set_level(logging.DEBUG if WINDOWS else logging.INFO)
 
     def initialize_pip_accel(self, load_environment_variables=False, **overrides):
         """

--- a/pip_accel/utils.py
+++ b/pip_accel/utils.py
@@ -137,6 +137,24 @@ def makedirs(path, mode=0o777):
             raise
         return False
 
+def same_directories(path1, path2):
+    """
+    Check if two pathnames refer to the same directory.
+
+    :param path1: The first pathname (a string).
+    :param path2: The second pathname (a string).
+    :returns: :data:`True` if both pathnames refer to the same directory,
+              :data:`False` otherwise.
+    """
+    if all(os.path.isdir(p) for p in (path1, path2)):
+        try:
+            return os.path.samefile(path1, path2)
+        except AttributeError:
+            # On Windows and Python 2 os.path.samefile() is unavailable.
+            return os.path.realpath(path1) == os.path.realpath(path2)
+    else:
+        return False
+
 def is_installed(package_name):
     """
     Check whether a package is installed in the current environment.

--- a/pip_accel/utils.py
+++ b/pip_accel/utils.py
@@ -58,7 +58,7 @@ def expand_path(pathname):
     pattern = r'^~(?=[\\/])' if WINDOWS else '^~(?=/)'
     logger.debug("Expanding pathname: %s", pathname)
     logger.debug("Using home directory: %s", home_directory)
-    pathname = re.sub(pattern, home_directory, pathname)
+    pathname = re.sub(pattern, re.escape(home_directory), pathname)
     logger.debug("Result of expansion #1: %s", pathname)
     pathname = parse_path(pathname)
     logger.debug("Result of expansion #2: %s", pathname)

--- a/pip_accel/utils.py
+++ b/pip_accel/utils.py
@@ -1,7 +1,7 @@
 # Utility functions for the pip accelerator.
 #
 # Author: Peter Odding <peter.odding@paylogic.com>
-# Last Change: October 27, 2015
+# Last Change: October 28, 2015
 # URL: https://github.com/paylogic/pip-accel
 
 """
@@ -15,6 +15,7 @@ with any single module.
 
 # Standard library modules.
 import errno
+import logging
 import os
 import platform
 import re
@@ -28,6 +29,8 @@ from humanfriendly import parse_path
 from pip.commands.uninstall import UninstallCommand
 from pkg_resources import WorkingSet
 
+# Initialize a logger for this module.
+logger = logging.getLogger(__name__)
 
 def compact(text, **kw):
     """
@@ -51,7 +54,15 @@ def expand_path(pathname):
                      directory of the current (effective) user.
     :returns: The (modified) pathname.
     """
-    return parse_path(re.sub('^~(?=/)', find_home_directory(), pathname))
+    home_directory = find_home_directory()
+    pattern = r'^~(?=[\\/])' if WINDOWS else '^~(?=/)'
+    logger.debug("Expanding pathname: %s", pathname)
+    logger.debug("Using home directory: %s", home_directory)
+    pathname = re.sub(pattern, home_directory, pathname)
+    logger.debug("Result of expansion #1: %s", pathname)
+    pathname = parse_path(pathname)
+    logger.debug("Result of expansion #2: %s", pathname)
+    return pathname
 
 def find_home_directory():
     """

--- a/pip_accel/utils.py
+++ b/pip_accel/utils.py
@@ -18,7 +18,6 @@ import errno
 import logging
 import os
 import platform
-import re
 import sys
 
 # Modules included in our package.
@@ -54,11 +53,14 @@ def expand_path(pathname):
                      directory of the current (effective) user.
     :returns: The (modified) pathname.
     """
-    home_directory = find_home_directory()
-    pattern = r'^~(?=[\\/])' if WINDOWS else '^~(?=/)'
     logger.debug("Expanding pathname: %s", pathname)
+    home_directory = find_home_directory()
     logger.debug("Using home directory: %s", home_directory)
-    pathname = re.sub(pattern, re.escape(home_directory), pathname)
+    separators = set([os.sep])
+    if os.altsep is not None:
+        separators.add(os.altsep)
+    if len(pathname) >= 2 and pathname[0] == '~' and pathname[1] in separators:
+        pathname = os.path.join(home_directory, pathname[2:])
     logger.debug("Result of expansion #1: %s", pathname)
     pathname = parse_path(pathname)
     logger.debug("Result of expansion #2: %s", pathname)

--- a/pip_accel/utils.py
+++ b/pip_accel/utils.py
@@ -15,7 +15,6 @@ with any single module.
 
 # Standard library modules.
 import errno
-import logging
 import os
 import platform
 import sys
@@ -27,9 +26,6 @@ from pip_accel.compat import WINDOWS
 from humanfriendly import parse_path
 from pip.commands.uninstall import UninstallCommand
 from pkg_resources import WorkingSet
-
-# Initialize a logger for this module.
-logger = logging.getLogger(__name__)
 
 def compact(text, **kw):
     """
@@ -53,18 +49,16 @@ def expand_path(pathname):
                      directory of the current (effective) user.
     :returns: The (modified) pathname.
     """
-    logger.debug("Expanding pathname: %s", pathname)
+    # The following logic previously used regular expressions but that approach
+    # turned out to be very error prone, hence the current contraption based on
+    # direct string manipulation :-).
     home_directory = find_home_directory()
-    logger.debug("Using home directory: %s", home_directory)
     separators = set([os.sep])
     if os.altsep is not None:
         separators.add(os.altsep)
     if len(pathname) >= 2 and pathname[0] == '~' and pathname[1] in separators:
         pathname = os.path.join(home_directory, pathname[2:])
-    logger.debug("Result of expansion #1: %s", pathname)
-    pathname = parse_path(pathname)
-    logger.debug("Result of expansion #2: %s", pathname)
-    return pathname
+    return parse_path(pathname)
 
 def find_home_directory():
     """

--- a/pip_accel/utils.py
+++ b/pip_accel/utils.py
@@ -1,7 +1,7 @@
 # Utility functions for the pip accelerator.
 #
 # Author: Peter Odding <peter.odding@paylogic.com>
-# Last Change: October 28, 2015
+# Last Change: October 29, 2015
 # URL: https://github.com/paylogic/pip-accel
 
 """
@@ -148,6 +148,33 @@ def same_directories(path1, path2):
             return os.path.realpath(path1) == os.path.realpath(path2)
     else:
         return False
+
+def replace_file(src, dst):
+    """
+    Overwrite a file (in an atomic fashion when possible).
+
+    :param src: The pathname of the source file (a string).
+    :param dst: The pathname of the destination file (a string).
+    """
+    # Try os.replace() which was introduced in Python 3.3
+    # (this should work on POSIX as well as Windows systems).
+    try:
+        os.replace(src, dst)
+        return
+    except AttributeError:
+        pass
+    # Try os.rename() which is atomic on UNIX but refuses to overwrite existing
+    # files on Windows.
+    try:
+        os.rename(src, dst)
+        return
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+    # Finally we fall back to the dumb approach required only on Windows.
+    # See https://bugs.python.org/issue8828 for a long winded discussion.
+    os.remove(dst)
+    os.rename(src, dst)
 
 def is_installed(package_name):
     """

--- a/scripts/collect-full-coverage
+++ b/scripts/collect-full-coverage
@@ -3,7 +3,7 @@
 # Shell script wrapper for the pip-accel test suite.
 #
 # Author: Peter Odding <peter.odding@paylogic.com>
-# Last Change: May 3, 2015
+# Last Change: October 27, 2015
 # URL: https://github.com/paylogic/pip-accel
 #
 # This shell script is used by the makefile of the pip-accel project to run the
@@ -164,7 +164,8 @@ prepare_python_packages () {
     # long as the test suite runs the automatic upgrade at least once (on
     # Python 2.6 and/or Python 2.7) I'm happy :-).
     msg "Downgrading setuptools (so the test suite can upgrade it) .."
-    pip install 'setuptools < 0.8'
+    # FYI: Binary wheels disabled to reduce test suite noise.
+    pip install --no-binary=:all: 'setuptools < 0.8'
   fi
 
   # Install requests==2.6.0 so the test suite can downgrade to requests==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # Setup script for the pip accelerator.
 #
 # Author: Peter Odding <peter.odding@paylogic.com>
-# Last Change: April 10, 2015
+# Last Change: October 29, 2015
 # URL: https://github.com/paylogic/pip-accel
 
 import re
@@ -51,4 +51,24 @@ setup(name='pip-accel',
       extras_require={'s3': 'boto >= 2.32'},
       package_data={'pip_accel.deps': ['*.ini']},
       install_requires=requirements,
-      test_suite='pip_accel.tests')
+      test_suite='pip_accel.tests',
+      classifiers=[
+          'Development Status :: 5 - Production/Stable',
+          'Environment :: Console',
+          'Intended Audience :: Developers',
+          'Intended Audience :: Information Technology',
+          'Intended Audience :: System Administrators',
+          'License :: OSI Approved :: MIT License',
+          'Operating System :: MacOS :: MacOS X',
+          'Operating System :: Microsoft :: Windows',
+          'Operating System :: POSIX :: Linux',
+          'Operating System :: Unix',
+          'Programming Language :: Python :: 2.6',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3.4',
+          'Topic :: Software Development :: Build Tools',
+          'Topic :: Software Development :: Libraries :: Python Modules',
+          'Topic :: System :: Archiving :: Packaging',
+          'Topic :: System :: Installation/Setup',
+          'Topic :: System :: Software Distribution',
+      ])

--- a/setup.py
+++ b/setup.py
@@ -6,30 +6,37 @@
 # Last Change: October 29, 2015
 # URL: https://github.com/paylogic/pip-accel
 
+# Standard library modules.
+import codecs
+import os
 import re
-from os.path import abspath, dirname, join
+
+# De-facto standard solution for Python packaging.
 from setuptools import setup, find_packages
 
 # Find the directory where the source distribution was unpacked.
-source_directory = dirname(abspath(__file__))
+source_directory = os.path.dirname(os.path.abspath(__file__))
 
 # Find the current version.
-module = join(source_directory, 'pip_accel', '__init__.py')
-for line in open(module):
-    match = re.match(r'^__version__\s*=\s*["\']([^"\']+)["\']$', line)
-    if match:
-        version_string = match.group(1)
-        break
-else:
-    raise Exception("Failed to extract version from %s!" % module)
+module = os.path.join(source_directory, 'pip_accel', '__init__.py')
+with open(module) as handle:
+    for line in handle:
+        match = re.match(r'^__version__\s*=\s*["\']([^"\']+)["\']$', line)
+        if match:
+            version_string = match.group(1)
+            break
+    else:
+        raise Exception("Failed to extract version from %s!" % module)
 
 # Fill in the long description (for the benefit of PyPI)
 # with the contents of README.rst (rendered by GitHub).
-readme_file = join(source_directory, 'README.rst')
-readme_text = open(readme_file).read()
+readme_file = os.path.join(source_directory, 'README.rst')
+with codecs.open(readme_file, 'r', 'utf-8') as handle:
+    readme_text = handle.read()
 
 # Fill in the "install_requires" field based on requirements.txt.
-requirements = [l.strip() for l in open(join(source_directory, 'requirements.txt'))]
+with open(os.path.join(source_directory, 'requirements.txt')) as handle:
+    requirements = [line.strip() for line in handle]
 
 setup(name='pip-accel',
       version=version_string,


### PR DESCRIPTION
This pull request summarizes the changes that @matysek, @theyoprst and I have made in order to add support for the Windows platform to pip-accel.

I merged the changes from pull request #60 into the [windows-support](https://github.com/paylogic/pip-accel/tree/windows-support) feature branch in order to restore Python 2.6 compatibility, fix some broken tests and finish the remaining TODO remarks (namely cache invalidation through atomic file replacement).

In the process of working on this feature branch I've set up automated continuous integration on Windows using [AppVeyor](https://ci.appveyor.com/project/xolox/pip-accel) so I'm also including the resulting `appveyor.yml` configuration file (to make testing forks easier).